### PR TITLE
feat:알러지 목록 조회 및 내 알러지 설정 화면 구현

### DIFF
--- a/lib/core/network/dio_client.dart
+++ b/lib/core/network/dio_client.dart
@@ -1,5 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:dio_cookie_manager/dio_cookie_manager.dart';
+import 'package:cookie_jar/cookie_jar.dart';
 
 final dioProvider = Provider<Dio>((ref) {
   final dio = Dio(
@@ -16,6 +18,10 @@ final dioProvider = Provider<Dio>((ref) {
       },
     ),
   );
+
+  // Cookie Manager
+  final cookieJar = CookieJar();
+  dio.interceptors.add(CookieManager(cookieJar));
 
   // Add interceptors here if needed (e.g., for logging or auth tokens)
   dio.interceptors.add(LogInterceptor(responseBody: true, requestBody: true));

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -1,8 +1,10 @@
-import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../features/auth/presentation/screens/login_screen.dart';
 import '../../features/auth/presentation/screens/signup_screen.dart';
+import '../../features/allergy/presentation/screens/allergy_selection_screen.dart';
+import '../../features/home/presentation/screens/home_screen.dart';
+import '../../features/profile/presentation/screens/profile_screen.dart';
 
 final routerProvider = Provider<GoRouter>((ref) {
   return GoRouter(
@@ -13,11 +15,17 @@ final routerProvider = Provider<GoRouter>((ref) {
         path: '/signup',
         builder: (context, state) => const SignUpScreen(),
       ),
+      GoRoute(path: '/home', builder: (context, state) => const HomeScreen()),
+
       GoRoute(
-        path: '/home',
-        builder: (context, state) => const Scaffold(
-          body: Center(child: Text('Home Screen')),
-        ), // Placeholder
+        path: '/profile',
+        builder: (context, state) => const ProfileScreen(),
+        routes: [
+          GoRoute(
+            path: 'allergy',
+            builder: (context, state) => const AllergySelectionScreen(),
+          ),
+        ],
       ),
     ],
   );

--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -3,12 +3,10 @@ import 'package:google_fonts/google_fonts.dart';
 
 class AppTheme {
   // Brand Colors
-  static const Color primaryColor = Color(0xFF009688); // Teal for Safety/Food
-  static const Color secondaryColor = Color(
-    0xFFFFA000,
-  ); // Amber for Warning/Attention
+  static const Color primaryColor = Color(0xFF2D6A4F); // Deep Forest Green
+  static const Color secondaryColor = Color(0xFFE9C46A); // Muted Gold
   static const Color errorColor = Color(0xFFD32F2F);
-  static const Color backgroundColor = Color(0xFFF5F5F5);
+  static const Color backgroundColor = Color(0xFFF8F9FA); // Warmer White
   static const Color surfaceColor = Colors.white;
 
   static ThemeData get lightTheme {

--- a/lib/features/allergy/data/models/allergy_model.dart
+++ b/lib/features/allergy/data/models/allergy_model.dart
@@ -1,0 +1,14 @@
+class Allergy {
+  final int id;
+  final String name;
+
+  Allergy({required this.id, required this.name});
+
+  factory Allergy.fromJson(Map<String, dynamic> json) {
+    return Allergy(id: json['id'] as int, name: json['name'] as String);
+  }
+
+  Map<String, dynamic> toJson() {
+    return {'id': id, 'name': name};
+  }
+}

--- a/lib/features/allergy/data/repositories/allergy_repository.dart
+++ b/lib/features/allergy/data/repositories/allergy_repository.dart
@@ -1,0 +1,89 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../../core/network/dio_client.dart';
+import '../models/allergy_model.dart';
+
+final allergyRepositoryProvider = Provider<AllergyRepository>((ref) {
+  final dio = ref.watch(dioProvider);
+  return AllergyRepository(dio);
+});
+
+class AllergyRepository {
+  final Dio _dio;
+
+  AllergyRepository(this._dio);
+
+  Future<List<Allergy>> getAllergies() async {
+    try {
+      final response = await _dio.get('/allergies');
+
+      List<dynamic> data;
+      if (response.data is Map &&
+          response.data.containsKey('result') &&
+          response.data['result'] is Map &&
+          response.data['result'].containsKey('allergies')) {
+        data = response.data['result']['allergies'];
+      } else if (response.data is List) {
+        data = response.data;
+      } else {
+        data = [];
+        print(
+          'Warning: Unexpected response format for getAllergies: ${response.data}',
+        );
+      }
+
+      return data.map((json) => Allergy.fromJson(json)).toList();
+    } catch (e) {
+      throw e;
+    }
+  }
+
+  Future<List<Allergy>> getMyAllergies() async {
+    try {
+      final response = await _dio.get('/allergies/my');
+
+      List<dynamic> data;
+      if (response.data is Map &&
+          response.data.containsKey('result') &&
+          response.data['result'] is Map &&
+          response.data['result'].containsKey('allergies')) {
+        data = response.data['result']['allergies'];
+      } else if (response.data is List) {
+        data = response.data;
+      } else {
+        data = [];
+        print(
+          'Warning: Unexpected response format for getMyAllergies: ${response.data}',
+        );
+      }
+
+      return data.map((json) => Allergy.fromJson(json)).toList();
+    } catch (e) {
+      throw e;
+    }
+  }
+
+  Future<void> updateMyAllergies(List<int> allergyIds) async {
+    try {
+      print('Updating allergies: $allergyIds');
+      // Changed key to 'allergyIds' based on backend validation error
+      final response = await _dio.put(
+        '/allergies/my',
+        data: {'allergyIds': allergyIds},
+      );
+
+      if (response.data is Map && response.data['isSuccess'] == false) {
+        throw DioException(
+          requestOptions: response.requestOptions,
+          response: response,
+          type: DioExceptionType.badResponse,
+          message: response.data['message'] ?? 'Update failed',
+        );
+      }
+      print('Update successful');
+    } catch (e) {
+      print('Update failed: $e');
+      throw e;
+    }
+  }
+}

--- a/lib/features/allergy/presentation/providers/allergy_provider.dart
+++ b/lib/features/allergy/presentation/providers/allergy_provider.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../data/repositories/allergy_repository.dart';
+import '../../data/models/allergy_model.dart';
+
+// Provider to fetch all available allergies
+final allergiesProvider = FutureProvider<List<Allergy>>((ref) async {
+  final repository = ref.watch(allergyRepositoryProvider);
+  return repository.getAllergies();
+});
+
+// Provider to fetch user's selected allergies
+final myAllergiesProvider = FutureProvider<List<Allergy>>((ref) async {
+  final repository = ref.watch(allergyRepositoryProvider);
+  return repository.getMyAllergies();
+});
+
+// StateNotifier to manage the selection state for the UI
+class AllergySelectionNotifier extends StateNotifier<Set<int>> {
+  final AllergyRepository _repository;
+  final Ref _ref;
+
+  AllergySelectionNotifier(this._repository, this._ref) : super({});
+
+  // Initialize with existing user allergies
+  void initialize(List<Allergy> myAllergies) {
+    state = myAllergies.map((e) => e.id).toSet();
+  }
+
+  void toggleAllergy(int id) {
+    if (state.contains(id)) {
+      state = {...state}..remove(id);
+    } else {
+      state = {...state}..add(id);
+    }
+  }
+
+  Future<void> saveMyAllergies() async {
+    await _repository.updateMyAllergies(state.toList());
+    _ref.invalidate(
+      myAllergiesProvider,
+    ); // Invalidate cache to force refetch next time
+  }
+}
+
+final allergySelectionProvider =
+    StateNotifierProvider<AllergySelectionNotifier, Set<int>>((ref) {
+      final repository = ref.watch(allergyRepositoryProvider);
+      return AllergySelectionNotifier(repository, ref);
+    });

--- a/lib/features/allergy/presentation/screens/allergy_selection_screen.dart
+++ b/lib/features/allergy/presentation/screens/allergy_selection_screen.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import '../providers/allergy_provider.dart';
+
+class AllergySelectionScreen extends ConsumerStatefulWidget {
+  const AllergySelectionScreen({super.key});
+
+  @override
+  ConsumerState<AllergySelectionScreen> createState() =>
+      _AllergySelectionScreenState();
+}
+
+class _AllergySelectionScreenState
+    extends ConsumerState<AllergySelectionScreen> {
+  bool _isInitialized = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final allergiesAsyncValue = ref.watch(allergiesProvider);
+    final myAllergiesAsyncValue = ref.watch(myAllergiesProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('알레르기 설정'),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => _handleSaveAndExit(context),
+        ),
+      ),
+      body: allergiesAsyncValue.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (err, stack) => Center(child: Text('오류: $err')),
+        data: (allAllergies) {
+          if (!_isInitialized) {
+            myAllergiesAsyncValue.whenData((myAllergies) {
+              Future.microtask(() {
+                if (mounted) {
+                  ref
+                      .read(allergySelectionProvider.notifier)
+                      .initialize(myAllergies);
+                  setState(() {
+                    _isInitialized = true;
+                  });
+                }
+              });
+            });
+          }
+
+          if (myAllergiesAsyncValue.isLoading && !_isInitialized) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          if (myAllergiesAsyncValue.hasError) {
+            return Center(
+              child: Text(
+                '내 알러지 목록을 불러오는데 실패했습니다: ${myAllergiesAsyncValue.error}',
+              ),
+            );
+          }
+
+          final selectedIds = ref.watch(allergySelectionProvider);
+
+          return ListView.builder(
+            itemCount: allAllergies.length,
+            itemBuilder: (context, index) {
+              final allergy = allAllergies[index];
+              final isSelected = selectedIds.contains(allergy.id);
+
+              return CheckboxListTile(
+                title: Text(allergy.name),
+                value: isSelected,
+                onChanged: (_) {
+                  ref
+                      .read(allergySelectionProvider.notifier)
+                      .toggleAllergy(allergy.id);
+                },
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+
+  Future<void> _handleSaveAndExit(BuildContext context) async {
+    try {
+      await ref.read(allergySelectionProvider.notifier).saveMyAllergies();
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('알러지 설정이 저장되었습니다'),
+            duration: Duration(seconds: 1),
+          ),
+        );
+        context.pop();
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('저장 실패: $e')));
+      }
+    }
+  }
+}

--- a/lib/features/auth/presentation/screens/login_screen.dart
+++ b/lib/features/auth/presentation/screens/login_screen.dart
@@ -41,7 +41,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
         error: (error, stack) {
           ScaffoldMessenger.of(
             context,
-          ).showSnackBar(SnackBar(content: Text('Login Failed: $error')));
+          ).showSnackBar(SnackBar(content: Text('로그인 실패: $error')));
         },
       );
     });
@@ -50,7 +50,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
     final isLoading = authState is AsyncLoading;
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Login')),
+      appBar: AppBar(title: const Text('로그인')),
       body: Padding(
         padding: const EdgeInsets.all(24.0),
         child: Form(
@@ -61,29 +61,27 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
             children: [
               TextFormField(
                 controller: _emailController,
-                decoration: const InputDecoration(labelText: 'Email'),
-                validator: (value) =>
-                    value!.isEmpty ? 'Please enter your email' : null,
+                decoration: const InputDecoration(labelText: '이메일'),
+                validator: (value) => value!.isEmpty ? '이메일을 입력해주세요' : null,
               ),
               const SizedBox(height: 16),
               TextFormField(
                 controller: _passwordController,
-                decoration: const InputDecoration(labelText: 'Password'),
+                decoration: const InputDecoration(labelText: '비밀번호'),
                 obscureText: true,
-                validator: (value) =>
-                    value!.isEmpty ? 'Please enter your password' : null,
+                validator: (value) => value!.isEmpty ? '비밀번호를 입력해주세요' : null,
               ),
               const SizedBox(height: 32),
               ElevatedButton(
                 onPressed: isLoading ? null : _onLogin,
                 child: isLoading
                     ? const CircularProgressIndicator()
-                    : const Text('Login'),
+                    : const Text('로그인'),
               ),
               const SizedBox(height: 16),
               TextButton(
                 onPressed: () => context.push('/signup'),
-                child: const Text('Don\'t have an account? Sign Up'),
+                child: const Text('계정이 없으신가요? 회원가입'),
               ),
             ],
           ),

--- a/lib/features/auth/presentation/screens/signup_screen.dart
+++ b/lib/features/auth/presentation/screens/signup_screen.dart
@@ -36,9 +36,9 @@ class _SignUpScreenState extends ConsumerState<SignUpScreen> {
 
       if (mounted && !ref.read(authProvider).hasError) {
         if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('Sign up successful! Please login.')),
-          );
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(const SnackBar(content: Text('회원가입 성공! 로그인해주세요.')));
           context.pop(); // Go back to login
         }
       }
@@ -52,7 +52,7 @@ class _SignUpScreenState extends ConsumerState<SignUpScreen> {
         error: (error, stack) {
           ScaffoldMessenger.of(
             context,
-          ).showSnackBar(SnackBar(content: Text('Sign Up Failed: $error')));
+          ).showSnackBar(SnackBar(content: Text('회원가입 실패: $error')));
         },
       );
     });
@@ -61,7 +61,7 @@ class _SignUpScreenState extends ConsumerState<SignUpScreen> {
     final isLoading = authState is AsyncLoading;
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Sign Up')),
+      appBar: AppBar(title: const Text('회원가입')),
       body: Padding(
         padding: const EdgeInsets.all(24.0),
         child: SingleChildScrollView(
@@ -73,31 +73,28 @@ class _SignUpScreenState extends ConsumerState<SignUpScreen> {
               children: [
                 TextFormField(
                   controller: _nameController,
-                  decoration: const InputDecoration(labelText: 'Name'),
-                  validator: (value) =>
-                      value!.isEmpty ? 'Please enter your name' : null,
+                  decoration: const InputDecoration(labelText: '이름'),
+                  validator: (value) => value!.isEmpty ? '이름을 입력해주세요' : null,
                 ),
                 const SizedBox(height: 16),
                 TextFormField(
                   controller: _emailController,
-                  decoration: const InputDecoration(labelText: 'Email'),
-                  validator: (value) =>
-                      value!.isEmpty ? 'Please enter your email' : null,
+                  decoration: const InputDecoration(labelText: '이메일'),
+                  validator: (value) => value!.isEmpty ? '이메일을 입력해주세요' : null,
                 ),
                 const SizedBox(height: 16),
                 TextFormField(
                   controller: _passwordController,
-                  decoration: const InputDecoration(labelText: 'Password'),
+                  decoration: const InputDecoration(labelText: '비밀번호'),
                   obscureText: true,
-                  validator: (value) =>
-                      value!.isEmpty ? 'Please enter your password' : null,
+                  validator: (value) => value!.isEmpty ? '비밀번호를 입력해주세요' : null,
                 ),
                 const SizedBox(height: 32),
                 ElevatedButton(
                   onPressed: isLoading ? null : _onSignUp,
                   child: isLoading
                       ? const CircularProgressIndicator()
-                      : const Text('Sign Up'),
+                      : const Text('회원가입'),
                 ),
               ],
             ),

--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('SafePlate')),
+      drawer: Drawer(
+        child: ListView(
+          padding: EdgeInsets.zero,
+          children: [
+            const DrawerHeader(
+              decoration: BoxDecoration(color: Colors.teal),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  CircleAvatar(
+                    backgroundColor: Colors.white,
+                    child: Icon(Icons.person, color: Colors.teal),
+                  ),
+                  SizedBox(height: 10),
+                  Text(
+                    '환영합니다!',
+                    style: TextStyle(color: Colors.white, fontSize: 20),
+                  ),
+                ],
+              ),
+            ),
+            ListTile(
+              leading: const Icon(Icons.check_box_outlined),
+              title: const Text('프로필 관리'),
+              onTap: () {
+                context.pop(); // Close drawer
+                context.push('/profile');
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.logout),
+              title: const Text('로그아웃'),
+              onTap: () {
+                context.pop(); // Close drawer
+                context.go('/login');
+              },
+            ),
+          ],
+        ),
+      ),
+      body: Stack(
+        children: [
+          // Google Map Placeholder
+          Container(
+            color: Colors.grey[300],
+            child: const Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(Icons.map, size: 64, color: Colors.grey),
+                  SizedBox(height: 16),
+                  Text(
+                    '구글 맵 (준비 중)',
+                    style: TextStyle(fontSize: 24, color: Colors.grey),
+                  ),
+                  Text(
+                    '(지도 기능을 사용하려면 API 키가 필요합니다)',
+                    style: TextStyle(color: Colors.grey),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          // Floating Info Card (Bottom Sheet style)
+          Positioned(
+            left: 16,
+            right: 16,
+            bottom: 32,
+            child: Card(
+              elevation: 4,
+              child: Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    const Text(
+                      '식당 정보',
+                      style: TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    const Text('지도에서 위치를 선택하여 정보를 확인하세요.'),
+                    const SizedBox(height: 16),
+                    ElevatedButton(
+                      onPressed: () {
+                        // TODO: Implement action
+                      },
+                      child: const Text('주변 검색'),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class ProfileScreen extends StatelessWidget {
+  const ProfileScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('프로필 관리')),
+      body: ListView(
+        padding: const EdgeInsets.all(16.0),
+        children: [
+          _buildMenuCard(
+            context,
+            title: '알레르기',
+            description: '자신의 알레르기 정보를 설정합니다.',
+            icon: Icons.check_box_outlined,
+            onTap: () => context.push('/profile/allergy'),
+            isActive: true,
+          ),
+          const SizedBox(height: 16),
+          _buildMenuCard(
+            context,
+            title: '종교',
+            description: '종교적 식이 제한을 설정합니다. (준비 중)',
+            icon: Icons.temple_buddhist_outlined,
+            onTap: () {},
+            isActive: false,
+          ),
+          const SizedBox(height: 16),
+          _buildMenuCard(
+            context,
+            title: '비건',
+            description: '채식 단계를 설정합니다. (준비 중)',
+            icon: Icons.grass,
+            onTap: () {},
+            isActive: false,
+          ),
+          const SizedBox(height: 16),
+          _buildMenuCard(
+            context,
+            title: '질병',
+            description: '질병에 따른 식이 제한을 설정합니다. (준비 중)',
+            icon: Icons.local_hospital_outlined,
+            onTap: () {},
+            isActive: false,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMenuCard(
+    BuildContext context, {
+    required String title,
+    required String description,
+    required IconData icon,
+    required VoidCallback onTap,
+    required bool isActive,
+  }) {
+    return Card(
+      elevation: 2,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: InkWell(
+        onTap: isActive ? onTap : null,
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.all(20.0),
+          child: Row(
+            children: [
+              CircleAvatar(
+                backgroundColor: isActive
+                    ? Theme.of(context).primaryColor.withOpacity(0.1)
+                    : Colors.grey.shade200,
+                child: Icon(
+                  icon,
+                  color: isActive
+                      ? Theme.of(context).primaryColor
+                      : Colors.grey,
+                ),
+              ),
+              const SizedBox(width: 16),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      title,
+                      style: TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.bold,
+                        color: isActive ? Colors.black87 : Colors.grey,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      description,
+                      style: TextStyle(
+                        fontSize: 14,
+                        color: isActive ? Colors.black54 : Colors.grey.shade400,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              if (isActive)
+                const Icon(
+                  Icons.arrow_forward_ios,
+                  size: 16,
+                  color: Colors.grey,
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -49,6 +49,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  cookie_jar:
+    dependency: "direct main"
+    description:
+      name: cookie_jar
+      sha256: a6ac027d3ed6ed756bfce8f3ff60cb479e266f3b0fdabd6242b804b6765e52de
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.8"
   crypto:
     dependency: transitive
     description:
@@ -73,6 +81,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.9.0"
+  dio_cookie_manager:
+    dependency: "direct main"
+    description:
+      name: dio_cookie_manager
+      sha256: d39c16abcc711c871b7b29bd51c6b5f3059ef39503916c6a9df7e22c4fc595e0
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.3.0"
   dio_web_adapter:
     dependency: transitive
     description:
@@ -429,6 +445,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  universal_io:
+    dependency: transitive
+    description:
+      name: universal_io
+      sha256: f63cbc48103236abf48e345e07a03ce5757ea86285ed313a6a032596ed9301e2
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.1"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,8 @@ dependencies:
   go_router: ^12.1.0
   google_fonts: ^6.1.0
   dio: ^5.4.0
+  dio_cookie_manager: ^3.2.0
+  cookie_jar: ^4.0.8
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 💫 PR 제목
- [Feature] 알레르기 설정 화면 및 데이터 연동 로직 구현
---

## 🔧 작업 내용 요약
- 알레르기 데이터 모델 (AllergyModel) 및 레포지토리 구현: 서버로부터 알레르기 목록을 불러오고 사용자의 설정을 저장하는 데이터 레이어를 구성했습니다.
- 상태 관리 (Riverpod Providers):
    - allergiesProvider: 전체 알레르기 목록 조회
    - myAllergiesProvider: 사용자가 설정한 알레르기 목록 조회
    - allergySelectionProvider: 화면 내 선택 상태 관리 및 저장 로직 담당
- UI 구현 (AllergySelectionScreen):
    - CheckboxListTile을 사용한 알레르기 다중 선택 UI 구현
    - 진입 시 기존 설정값을 불러와 초기화하는 로직 추가
    - '뒤로가기' 버튼 클릭 시 변경사항을 저장하고 종료하는 기능 구현 (_handleSaveAndExit)


---

## 🔍 중점적으로 리뷰받고 싶은 부분
- 상태 초기화 로직: build 메서드 내에서 myAllergiesAsyncValue 데이터가 로드되었을 때 _isInitialized 플래그를 사용하여 allergySelectionProvider를 한 번만 초기화하도록 구현했습니다. 이 패턴이 적절한지, 더 나은 방법(예: Riverpod의 다른 패턴 활용)이 있을지 피드백 부탁드립니다.
- 예외 처리: 저장 실패 시 스낵바를 띄우도록 처리했는데, 사용자 경험 측면에서 충분한지 확인 부탁드립니다.

---

## 🔗 관련 이슈
- closes #4

---

## 📝 기타 참고 사항
- 현재 dio_client와 연동되어 실제 API 호출이 이루어지도록 구성되어 있습니다.
- UI 테스트를 위해서는 백엔드 서버 구동이 필요합니다.
